### PR TITLE
sg list instances

### DIFF
--- a/app/controllers/instances_controller.rb
+++ b/app/controllers/instances_controller.rb
@@ -1,5 +1,13 @@
 class InstancesController < ApplicationController
 
+  def index
+    ec2_instance = Ec2Instance.new(region: 'us-east-1')
+    @list = ec2_instance.list
+    if @list.nil?
+      flash.now[:error] = "No instances defined"
+    end
+  end
+
   def show
     @id = params[:id]
     ec2_instance = Ec2Instance.new(id: @id)

--- a/app/views/instances/index.html.erb
+++ b/app/views/instances/index.html.erb
@@ -1,0 +1,25 @@
+<div>
+  <h3>EC2 Instances</h3>
+
+  <% if @list %>
+    <table>
+      <tbody>
+        <tr>
+          <th>Instance id</th>
+          <th>Name</th>
+          <th>State</th>
+        </tr>
+        <% @list.each do |instance| %>
+          <tr >
+            <td><%= instance['Instance id'] %></td>
+            <td><%= instance['Instance name'] %></td>
+            <td><%= instance['State'] %></td>
+            <td><%= link_to 'Show', instance_url(instance['Instance id']) %>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+    <br><%= link_to "Refresh", instances_url(@id) %>
+  <% end %>
+
+</div>

--- a/app/views/instances/show.html.erb
+++ b/app/views/instances/show.html.erb
@@ -15,6 +15,8 @@
     <br><%= link_to "Refresh", instance_url(@id) %>
     <br><%= link_to "Start Instance", instance_start_url(@id) %>
     <br><%= link_to "Stop Instance", instance_stop_url(@id) %>
+    <br>
+    <br><%= link_to "Back to List", instances_url %>
   <% end %>
 
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
 
-  resources :instances, only: [:show] do
+  resources :instances, only: [:index, :show] do
     get "/start" => "instances#start", :as => :start
     get "/stop" => "instances#stop", :as => :stop
   end

--- a/spec/models/ec2_instance_spec.rb
+++ b/spec/models/ec2_instance_spec.rb
@@ -5,6 +5,32 @@ describe Ec2Instance do
     Aws.config.update(stub_responses: true)
   end
 
+  describe '.list' do
+    context 'given an instance is defined' do
+      it 'returns a list with info of one instance' do
+        Aws.config[:ec2] = instance_exists_stub
+
+        instance = Ec2Instance.new(id: 'id-exists', region: 'us-east-1')
+        instance_list = instance.list
+
+        expect(instance_list[0]['Instance id']).to be
+        expect(instance_list[0]['Instance name']).to be
+        expect(instance_list[0]['State']).to be
+      end
+    end
+
+    context 'given there are no instances defined' do
+      it 'returns an empty array' do
+        Aws.config[:ec2] = instance_does_not_exist_stub
+
+        instance = Ec2Instance.new(id: 'id-not-exist', region: 'us-east-1')
+        instance_list = instance.list
+
+        expect(instance_list).to be_empty
+      end
+    end
+  end
+
   describe '.description' do
     context 'given an existing instance' do
       it 'returns instance description' do


### PR DESCRIPTION
List all EC2 instances with id, name and status

Lists the instances and provides the option to view details about the instance, accessed by

/instances

Related rspec tests added to EC2Instance model
